### PR TITLE
Added RequestEventMiddleware and the ability to access the request_event

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,15 @@ Zask Changelog
 
 Here you can see the full list of changes between each Zask release.
 
+Version 1.9.3
+-------------
+
+released on July 28th 2016
+
+* Added RequestEventMiddleware
+* request_event now accessible inside service endpoint via get_request_event()
+
+
 Version 1.9.2
 -------------
 

--- a/zask/__init__.py
+++ b/zask/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '1.9.2'
+__version__ = '1.9.3'
 
 import gevent
 from gevent.local import local

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -622,4 +622,4 @@ class MissingMiddlewareException(Exception):
         self.middleware = middleware
 
     def __str__(self):
-        return "Missing required middleware %s." % self.middleware
+        return 'Missing required middleware {}.'.format(self.middleware)

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -13,6 +13,7 @@ import time
 import inspect
 import uuid
 
+from functools import partial
 from logging import getLogger, StreamHandler, Formatter, DEBUG, INFO, ERROR
 from logging.handlers import TimedRotatingFileHandler
 
@@ -47,10 +48,12 @@ CONFIG_ENDPOINT_MIDDLEWARE = 'file'
 CONFIG_CUSTOME_HEADER_MIDDLEWARE = 'header'
 ACCESS_LOG_MIDDLEWARE = 'access_log'
 REQUEST_CHAIN_MIDDLEWARE = 'uuid'
+REQUEST_EVENT_MIDDLEWARE = 'event'
 DEFAULT_MIDDLEWARES = [
     CONFIG_CUSTOME_HEADER_MIDDLEWARE,
     REQUEST_CHAIN_MIDDLEWARE,
-    ACCESS_LOG_MIDDLEWARE
+    ACCESS_LOG_MIDDLEWARE,
+    REQUEST_EVENT_MIDDLEWARE
 ]
 
 
@@ -235,6 +238,15 @@ class RequestChainMiddleware(object):
                 'uuid': self.get_uuid(),
             })
 
+class RequestEventMiddleware(object):
+    """Exposes the request_event to the object being passed to Server()
+    via self.get_request_event() from a service endpoint.
+    """
+
+    def server_before_exec(self, request_event):
+        """Injects the request_event into greenlet's local storage context.
+        """
+        setattr(_request_ctx.stash, 'request_event', request_event)
 
 class AccessLogMiddleware(object):
 
@@ -386,6 +398,10 @@ class ZeroRPC(object):
 
         if ACCESS_LOG_MIDDLEWARE in self._middlewares:
             context.register_middleware(AccessLogMiddleware(self.app))
+
+        if REQUEST_EVENT_MIDDLEWARE in self._middlewares:
+            context.register_middleware(RequestEventMiddleware())
+
         _Server.__context__ = _Client.__context__ = context
 
     def register_middleware(self, middleware):
@@ -436,6 +452,10 @@ class _Server(zerorpc.Server):
                                 heartbeat=heartbeat,
                                 **kargs)
 
+        # Inject get_request_event *after* Server constructor so that
+        # it's not exposed to the RPC from the outside.
+        methods.get_request_event = self._get_request_event
+
         for instance in context_._middlewares:
             if isinstance(instance, ConfigEndpointMiddleware):
                 if methods.__version__ is None:
@@ -448,6 +468,16 @@ class _Server(zerorpc.Server):
                 instance.set_server_version(methods.__version__)
             if isinstance(instance, AccessLogMiddleware):
                 instance.set_class_name(methods.__class__.__name__)
+
+    def _get_request_event(self):
+        """Returns the request_event from the local greenlet storage.
+        Requires RequestEventMiddleware to be enabled to work.
+        """
+        enabled_middlewares = [mw.__class__.__name__ for mw in
+                               self.__context__._middlewares]
+        if 'RequestEventMiddleware' not in enabled_middlewares:
+            raise MissingMiddlewareException('RequestEventMiddleware')
+        return getattr(_request_ctx.stash, 'request_event')
 
 
 class _Client(zerorpc.Client):
@@ -585,3 +615,12 @@ class NoNameException(Exception):
 
     def __str__(self):
         return "__service_name__ is needed for ZeroRPC server"
+
+
+class MissingMiddlewareException(Exception):
+
+    def __init__(self, middleware):
+        self.middleware = middleware
+
+    def __str__(self):
+        return "Missing required middleware %s." % self.middleware

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -617,6 +617,9 @@ class NoNameException(Exception):
 
 
 class MissingMiddlewareException(Exception):
+    """Raised when Zask tries to invoke a functionality provided
+    by a specific middleware, but that middleware is not loaded.
+    """
 
     def __init__(self, middleware):
         self.middleware = middleware

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -13,7 +13,6 @@ import time
 import inspect
 import uuid
 
-from functools import partial
 from logging import getLogger, StreamHandler, Formatter, DEBUG, INFO, ERROR
 from logging.handlers import TimedRotatingFileHandler
 


### PR DESCRIPTION
## Summary of changes
- Added a new middleware, `RequestEventMiddleware` (enabled by default) which allows a service endpoint to access the `request_event` variable by calling `get_request_event()` (see example usage below).
- Modified `zask.ext.zerorpc._Server` to support the functionalities of above-mentioned middleware, while keeping it only accessible from within the server (not callable via RPC)
## How to Test
- Set up Zask locally using this branch

``` bash
$ git clone git@github.com:kixpanganiban/zask
$ cd zask
$ git checkout feature/request-event-middleware
$ virtualenv my_env
$ source my_env/bin/activate
$ python setup.py develop
```
- Create a test service that invokes Zask. Here's the one I used (save it as test.py):

``` python
import json

from zask import Zask
from zask.ext.zerorpc import ZeroRPC

app = Zask('testapp')
app.config['ZERORPC_TESTAPP'] = {
    '1.0': 'tcp://0.0.0.0:9999'
    }
rpc = ZeroRPC()
rpc.init_app(app)


class TestApp(object):
    __service_name__ = 'testapp'
    __version__ = '1.0'

    def ping(self):
        request_event = self.get_request_event()
        print request_event.header
        return json.dumps({"response": "pong"})

server = rpc.Server(TestApp())
server.run()
```
- Run it

``` bash
$ python test.py
```
- On a separate terminal session, invoke ZeroRPC and your first terminal session should show the request being received as well as the contents of the `request_event.header` being printed.

Terminal 1

``` bash
$ zerorpc --json tcp://0.0.0.0:9999 ping
'{"response": "pong"}'
```

Terminal 2 (yours may not be exact)

``` bash
{'uuid': '0f3c7d75-4f14-11e6-887c-0c4de9b2f06f', 'started_at': 1469085825501, 'message_id': '83d10532-1e45-44fd-bd46-0fb83e9ae507', 'v': 3}
- - - [21/Jul/2016:07:23:45 +0000] "TestApp ping" OK - - - - 0 0f3c7d75-4f14-11e6-887c-0c4de9b2f06f
```

/fyi: @tjoelsson, @imlazyone 
