### PR TITLE
Fix some Exceptions not being propagated properly.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,14 @@ Zask Changelog
 
 Here you can see the full list of changes between each Zask release.
 
+Version 1.9.4
+-------------
+
+released on August 16th 2016
+
+* Fixed a bug that prevents Exceptions from properly propagating when there is no started_at in the event header
+
+
 Version 1.9.3
 -------------
 

--- a/zask/__init__.py
+++ b/zask/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '1.9.3'
+__version__ = '1.9.4'
 
 import gevent
 from gevent.local import local

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -284,7 +284,6 @@ class AccessLogMiddleware(object):
 
     def server_inspect_exception(self, request_event, reply_event, task_context, exc_infos):
         start = request_event.header.get('started_at')
-        request_time = lambda s: _milli_time() - s if s else 0
         message = '"%s %s"' % (self._class_name, request_event.name)
         access_key = request_event.header.get('access_key', '-')
         uuid = request_event.header.get('uuid', '-')
@@ -297,7 +296,7 @@ class AccessLogMiddleware(object):
             'referrer': '-',
             'user_agent': '-',
             'cookies': '-',
-            'request_time': request_time(start),
+            'request_time': _milli_time() - start if start else 0,
             'uuid': uuid,
         })
 

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -284,6 +284,7 @@ class AccessLogMiddleware(object):
 
     def server_inspect_exception(self, request_event, reply_event, task_context, exc_infos):
         start = request_event.header.get('started_at')
+        request_time = lambda s: _milli_time() - s if s else 0
         message = '"%s %s"' % (self._class_name, request_event.name)
         access_key = request_event.header.get('access_key', '-')
         uuid = request_event.header.get('uuid', '-')
@@ -296,7 +297,7 @@ class AccessLogMiddleware(object):
             'referrer': '-',
             'user_agent': '-',
             'cookies': '-',
-            'request_time': _milli_time() - start,
+            'request_time': request_time(start),
             'uuid': uuid,
         })
 


### PR DESCRIPTION
## Summary of changes

Sometimes, an Exception that occurs on the server side (most notably during `NoSuchAccessKeyException`s), another exception breaks the propagation chain when the internal Zask logger fails to find the `started_at` key in the header. This PR makes it so that when the `started_key` is not found, `request_time` is automatically set to `0` to allow the chain to continue properly.
## How to Test

 1. Download [zask-fix-test.py](https://gist.github.com/KixPanganiban/744237838ce2111f58800da307b5c25d) and save it in the root of your Zask repo.
 2. Checkout `master` branch from the main `juwai` repository, and run `ve python zask-fix-test.py`. You should see something similar to:

``` python
ERROR:zerorpc.core:
Traceback (most recent call last):
  File "/Users/kix/Juwai/zask/.virtualenv/lib/python2.7/site-packages/zerorpc-0.5.1-py2.7.egg/zerorpc/core.py", line 145, in _async_task
    self._context.hook_load_task_context(event.header)
  File "/Users/kix/Juwai/zask/.virtualenv/lib/python2.7/site-packages/zerorpc-0.5.1-py2.7.egg/zerorpc/context.py", line 139, in hook_load_task_context
    functor(event_header)
  File "/Users/kix/Juwai/zask/zask/ext/zerorpc/__init__.py", line 199, in load_task_context
    raise NoSuchAccessKeyException(event_header.get('access_key'))
NoSuchAccessKeyException: No such key 'testapp'.
Traceback (most recent call last):
  File "/Users/kix/Juwai/zask/.virtualenv/lib/python2.7/site-packages/gevent-1.1.1-py2.7-macosx-10.10-intel.egg/gevent/greenlet.py", line 534, in run
    result = self._run(*self.args, **self.kwargs)
  File "/Users/kix/Juwai/zask/.virtualenv/lib/python2.7/site-packages/zerorpc-0.5.1-py2.7.egg/zerorpc/core.py", line 158, in _async_task
    self._context.hook_server_inspect_exception(event, reply_event, exc_infos)
  File "/Users/kix/Juwai/zask/.virtualenv/lib/python2.7/site-packages/zerorpc-0.5.1-py2.7.egg/zerorpc/context.py", line 178, in hook_server_inspect_exception
    functor(request_event, reply_event, task_context, exc_infos)
  File "/Users/kix/Juwai/zask/zask/ext/zerorpc/__init__.py", line 299, in server_inspect_exception
    'request_time': _milli_time() - start,
TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
<Greenlet at 0x10bd8b910: <bound method _Server._async_task of <zask.ext.zerorpc._Server object at 0x10bef9510>>(<zerorpc.events.Event object at 0x10c020230>)> failed with TypeError
```

_Because the execution chain of the server greenlet halted abruptly, no response will be sent to the client and the client will see this as a Timeout error._

3. Checkout this branch: `git remote add kixpanganiban git@github.com:kixpanganiban/zask.git && git fetch kixpanganiban && git checkout kixpanganiban/fix/exceptions`, and run `ve python zask-fix-test.py`. You should now see:

``` python
ERROR:zerorpc.core:
Traceback (most recent call last):
  File "/Users/kix/Juwai/zask/.virtualenv/lib/python2.7/site-packages/zerorpc-0.5.1-py2.7.egg/zerorpc/core.py", line 145, in _async_task
    self._context.hook_load_task_context(event.header)
  File "/Users/kix/Juwai/zask/.virtualenv/lib/python2.7/site-packages/zerorpc-0.5.1-py2.7.egg/zerorpc/context.py", line 139, in hook_load_task_context
    functor(event_header)
  File "/Users/kix/Juwai/zask/zask/ext/zerorpc/__init__.py", line 199, in load_task_context
    raise NoSuchAccessKeyException(event_header.get('access_key'))
NoSuchAccessKeyException: No such key 'testapp'.
INFO:zask.ext.zerorpc:"TestApp ping"
NoSuchAccessKeyException: No such key 'testapp'.
```

As you can see, the Exception `NoSuchAccessKeyException` has been properly propagated to the client.

/fyi: @tjoelsson, @imlazyone Please review.
