### PR TITLE
upgrade sqlalchemy version to 1.2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'zerorpc>=0.5.1, <0.7',
-        'sqlalchemy>=1.1.11, <1.3'
+        'sqlalchemy>=0.9.8, <1.3'
     ],
     classifiers=[
         'Environment :: Other Environment',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'zerorpc>=0.5.1, <0.7',
-        'sqlalchemy>=0.9.8, <1.2'
+        'sqlalchemy>=1.1.11, <1.3'
     ],
     classifiers=[
         'Environment :: Other Environment',

--- a/zask/ext/sqlalchemy/__init__.py
+++ b/zask/ext/sqlalchemy/__init__.py
@@ -354,7 +354,8 @@ class SQLAlchemy(object):
         # as we gonna run zask as a daemon, set pool_recycle as default
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', 3600)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
-        app.config.setdefault('POOL_PRE_PING', False)
+        if sqlalchemy.__version__.startswith('1.2'):
+            app.config.setdefault('POOL_PRE_PING', False)
 
         if not hasattr(app, 'extensions'):
             app.extensions = {}
@@ -368,8 +369,9 @@ class SQLAlchemy(object):
         _setdefault('pool_size', 'SQLALCHEMY_POOL_SIZE')
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
-        _setdefault('pool_pre_ping', 'POOL_PRE_PING')
         _setdefault('max_overflow', 'SQLALCHEMY_MAX_OVERFLOW')
+        if sqlalchemy.__version__.startswith('1.2'):
+            _setdefault('pool_pre_ping', 'POOL_PRE_PING')
 
     def apply_driver_hacks(self, app, info, options):
         """This method is called before engine creation and used to inject

--- a/zask/ext/sqlalchemy/__init__.py
+++ b/zask/ext/sqlalchemy/__init__.py
@@ -354,6 +354,7 @@ class SQLAlchemy(object):
         # as we gonna run zask as a daemon, set pool_recycle as default
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', 3600)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
+        app.config.setdefault('POOL_PRE_PING', False)
 
         if not hasattr(app, 'extensions'):
             app.extensions = {}
@@ -367,6 +368,7 @@ class SQLAlchemy(object):
         _setdefault('pool_size', 'SQLALCHEMY_POOL_SIZE')
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
+        _setdefault('pool_pre_ping', 'POOL_PRE_PING')
         _setdefault('max_overflow', 'SQLALCHEMY_MAX_OVERFLOW')
 
     def apply_driver_hacks(self, app, info, options):


### PR DESCRIPTION
## Summary of changes

upgrade sqlalchemy version to 1.2.8
try to use sqlalchemy new features: `pool_pre_ping`

## How to Test

1. sqlachemy document:

http://docs.sqlalchemy.org/en/latest/core/pooling.html#disconnect-handling-pessimistic



@tjoelsson @mark-juwai 
