### PR TITLE
add new file handler for production logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ target/
 
 # Mac
 .DS_Store
+
+# IDE
+.idea
+.vscode

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,13 @@ Zask Changelog
 
 Here you can see the full list of changes between each Zask release.
 
+Version 1.9.7
+-------------
+
+released on April 10th 2019
+
+* Add new handler for production logger
+
 Version 1.9.6
 -------------
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -49,5 +49,27 @@ class TestLogging(unittest.TestCase):
         with open(app.config['ERROR_LOG'], 'r') as fin:
             print fin.read()
 
+    def test_prod_class(self):
+        app = Zask(__name__)
+        app.config = self.default_config
+        app.config['DEBUG'] = False
+        app.config['PRODUCTION_LOGGING_CLASS'] = 'WatchedFileHandler'
+
+        app.logger.debug("debug")
+        app.logger.info("info")
+        app.logger.warning("warning")
+        app.logger.error("error")
+        app.logger.exception("exception")
+
+        self.assertEqual(len(app.logger.handlers), 1)
+        hdlr = app.logger.handlers[0]
+        self.assertEqual(hdlr.__class__.__name__, 'WatchedFileHandler')
+
+        print ''
+        print 'printing file:'
+        with open(app.config['ERROR_LOG'], 'r') as fin:
+            print fin.read()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/zask/__init__.py
+++ b/zask/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '1.9.6'
+__version__ = '1.9.7'
 
 import gevent
 from gevent.local import local

--- a/zask/logging.py
+++ b/zask/logging.py
@@ -81,5 +81,6 @@ def _get_production_logging_level(config):
         'WARNING': logging.WARNING,
         'ERROR': logging.ERROR
     }
-    return mapping.get(config['PRODUCTION_LOGGING_LEVEL'].upper())\
-           or logging.INFO
+    return mapping.get(
+        config['PRODUCTION_LOGGING_LEVEL'].upper()
+    ) or logging.INFO


### PR DESCRIPTION
## Summary of changes

- use logging dictConfig to make logging configurable

## How to Test
- create a setting config like `.dev.settings.cfg` and add below config
- set the `'PRODUCTION_LOGGING_CLASS' = 'WatchedFileHandler'` in you config
- see logs in your log file

/fyi: @zhangjustin @mark-juwai  pls review
