### PR TITLE
Add origin_access_key to RequestChainMiddleware

### DIFF
--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -211,6 +211,11 @@ class RequestChainMiddleware(object):
             setattr(_request_ctx.stash, 'uuid', str(uuid.uuid1()))
         return _request_ctx.stash.uuid
 
+    def get_origin_access_key(self):
+        if not hasattr(_request_ctx.stash, 'origin_access_key'):
+            return None
+        return _request_ctx.stash.origin_access_key
+
     def set_uuid(self, uuid):
         setattr(_request_ctx.stash, 'uuid', uuid)
 
@@ -225,9 +230,22 @@ class RequestChainMiddleware(object):
             })
         else:
             self.set_uuid(request_event.header.get('uuid'))
+        if request_event.header.get('origin_access_key'):
+            self.set_origin_access_key(
+                request_event.header.get('origin_access_key'))
+        elif request_event.header.get('access_key'):
+            self.set_origin_access_key(request_event.header.get('access_key'))
+
+    def set_origin_access_key(self, origin_access_key):
+        setattr(_request_ctx.stash, 'origin_access_key', origin_access_key)
+
+    def clear_origin_access_key(self):
+        if hasattr(_request_ctx.stash, 'origin_access_key'):
+            delattr(_request_ctx.stash, 'origin_access_key')
 
     def server_after_exec(self, request_event, reply_event):
         self.clear_uuid()
+        self.clear_origin_access_key()
 
     def server_inspect_exception(
             self,
@@ -242,14 +260,10 @@ class RequestChainMiddleware(object):
             event.header.update({
                 'uuid': self.get_uuid(),
             })
-        if event.header.get('origin_access_key'):
-            event.header.update({
-                'origin_access_key': event.header.get('origin_access_key')
-            })
-        else:
-            if event.header.get('access_key'):
+        if not event.header.get('origin_access_key'):
+            if self.get_origin_access_key():
                 event.header.update({
-                    'origin_access_key': event.header.get('access_key')
+                    'origin_access_key': self.get_origin_access_key()
                 })
 
 

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -246,11 +246,11 @@ class RequestChainMiddleware(object):
             event.header.update({
                 'origin_access_key': event.header.get('origin_access_key')
             })
-        if event.header.get('access_key') and not \
-                event.header.get('origin_access_key'):
-            event.header.update({
-                'origin_access_key': event.header.get('access_key')
-            })
+        else:
+            if event.header.get('access_key'):
+                event.header.update({
+                    'origin_access_key': event.header.get('access_key')
+                })
 
 
 class RequestEventMiddleware(object):

--- a/zask/ext/zerorpc/__init__.py
+++ b/zask/ext/zerorpc/__init__.py
@@ -242,6 +242,15 @@ class RequestChainMiddleware(object):
             event.header.update({
                 'uuid': self.get_uuid(),
             })
+        if event.header.get('origin_access_key'):
+            event.header.update({
+                'origin_access_key': event.header.get('origin_access_key')
+            })
+        if event.header.get('access_key') and not \
+                event.header.get('origin_access_key'):
+            event.header.update({
+                'origin_access_key': event.header.get('access_key')
+            })
 
 
 class RequestEventMiddleware(object):


### PR DESCRIPTION
## Summary of changes

If your request is a chain request in RPC internal, add  the origin access key to internal service

## How to Test
0. Install my branch code
```
pip install git+https://github.com/zhangjustin/zask.git@PLAT-1259
```

1.  add follow code to your chain service endpoint
```
print(self.get_request_event().header)
```
try to visit your RPC service with access key, check the print in last chain service endpoint. you'll find `origin_access_key`

2. If you visit RPC service with zerorpc command line, then you can't get origin_access_key, because the visit doesn't take `access_key`.


/fyi:  @mark-juwai ,  @xxh840912  @tjoelsson : Please review.

/cc: _@mention_: Need your input regarding _concern_.